### PR TITLE
Fix doubled up 'syntax--' prefix

### DIFF
--- a/styles/base.less
+++ b/styles/base.less
@@ -279,33 +279,33 @@ atom-text-editor .search-results .syntax--marker.current-result .region {
     }
   }
 
-  &.syntax--syntax--name.syntax--syntax--class,
+  &.syntax--name.syntax--class,
   // class declarations, Java, Ruby, PHP, Python
-  &.syntax--syntax--name.syntax--syntax--type.syntax--syntax--class {
+  &.syntax--name.syntax--type.syntax--class {
     color: @yellow;
   }
 
-  &.syntax--syntax--name.syntax--syntax--section {
+  &.syntax--name.syntax--section {
     color: @syntax-text-color;
   }
 
-  &.syntax--syntax--name.syntax--syntax--tag {
+  &.syntax--name.syntax--tag {
     color: @dark-green;
   }
 
-  &.syntax--syntax--other.syntax--syntax--attribute-name {
+  &.syntax--other.syntax--attribute-name {
     color: @light-green;
 
-    &.syntax--syntax--html{
+    &.syntax--html{
       color: @yellow;
     }
   }
 
-  &.syntax--syntax--name.syntax--syntax--type {
+  &.syntax--name.syntax--type {
     color: @yellow;
   }
 
-  &.syntax--syntax--other.syntax--syntax--inherited-class {
+  &.syntax--other.syntax--inherited-class {
     color: @yellow;
   }
 }


### PR DESCRIPTION
This was my fault, somehow the new `syntax--` prefix ended up twice on some classes. Caused problems for XML and maybe some others.