### PR TITLE
Selection Background

### DIFF
--- a/styles/colors.less
+++ b/styles/colors.less
@@ -20,4 +20,4 @@
 
 @bg-color: #2D2C2B;
 @white-text-color: #C0D5C1;
-@selection-color: #9FE5EB;
+@selection-color: rgba(245, 197, 04, 0.1);


### PR DESCRIPTION
When hovering a class or function name, the ide will show you some info about it and change the background color of the whole block to `@selection-color`. As it is, sky blue is not very suitable. Here is a much more subtle brown. I think it fits the rest of the theme much better.